### PR TITLE
replace fuzzywuzzy

### DIFF
--- a/chatbot/automatic.py
+++ b/chatbot/automatic.py
@@ -7,7 +7,7 @@ import utils.yarrrml_serializer as YARRRML
 from chatbot.semantic_engine import get_field_class, get_field_property, _get_uri_suffix
 
 from django.conf import settings
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "chatbot_app.settings")
 
@@ -85,7 +85,7 @@ def find_field(class_correspondance, fields):
             field_class_strings = fields[name]['strings']
             for field_string in field_class_strings:
                 for class_string in class_strings:
-                    if fuzz.token_set_ratio(field_string, class_string) >= 90:
+                    if fuzz.token_set_ratio(field_string, class_string, score_cutoff=90):
                         return fields[name]
     return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ requests>=2.18
 Django==1.11.29
 hdt>=2.0
 pytest>=4.0.1
-fuzzywuzzy>=0.17.0
-python-Levenshtein>=0.12.0
+rapidfuzz>=0.12.2
 PyYAML>=5.1
 simplejson>=3.16.0
 django_webpack_loader==0.6.0

--- a/utils/lov_ods_api.py
+++ b/utils/lov_ods_api.py
@@ -1,7 +1,7 @@
 import re
 
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from django.conf import settings
 


### PR DESCRIPTION
FuzzyWuzzy is GPL Licensed, which is incompatible with the license used by this project. This Pull Request replaces FuzzyWuzzy with [RapidFuzz](https://github.com/maxbachmann/rapidfuzz), which implements the same algorithms. It is licensed in a compatible way (MIT License) and is faster than FuzzyWuzzy. 